### PR TITLE
feat: use 'query' param and add cache headers to command search

### DIFF
--- a/backend/src/controllers/commandsController.js
+++ b/backend/src/controllers/commandsController.js
@@ -119,7 +119,7 @@ export class CommandController {
       if (!searchQuery) {
         return next(
           new BadRequestError(
-            "Query parameter 'q' is required and must be a non-empty string",
+            "Query parameter 'query' is required and must be a non-empty string",
           ),
         );
       }
@@ -129,6 +129,9 @@ export class CommandController {
         query: searchQuery,
         limit: resultLimit,
       });
+
+      res.set('Cache-Control', 'private, no-cache, max-age=0, must-revalidate');
+      res.set('Vary', 'Authorization');
 
       return res.json(searchResults);
     } catch (error) {

--- a/backend/src/models/mongo/commandModel.js
+++ b/backend/src/models/mongo/commandModel.js
@@ -183,13 +183,13 @@ export class CommandModel {
 
     if (!trimmedQuery || trimmedQuery.length === 0) {
       throw new BadRequestError(
-        "Query parameter 'q' must be a non-empty string",
+        "Query parameter 'query' must be a non-empty string",
       );
     }
 
     if (trimmedQuery.length > SEARCH_CONFIG.MAX_QUERY_LENGTH) {
       throw new BadRequestError(
-        `Query parameter 'q' must not exceed ${SEARCH_CONFIG.MAX_QUERY_LENGTH} characters`,
+        `Query parameter 'query' must not exceed ${SEARCH_CONFIG.MAX_QUERY_LENGTH} characters`,
       );
     }
   };

--- a/backend/src/router/router.js
+++ b/backend/src/router/router.js
@@ -313,7 +313,7 @@ export const createRouter = ({ commandModel, userModel }) => {
      *     tags: [Commands v2]
      *     parameters:
      *       - in: query
-     *         name: q
+     *         name: query
      *         required: true
      *         schema:
      *           type: string


### PR DESCRIPTION
- Rename template search param from 'q' to 'query' across controller, model, and router/OpenAPI docs for clarity and consistency

- Update param validation messages and example requests to use 'query'

- Add secure cache-control headers in commandsController:
    - Cache-Control: private, no-cache, max-age=0, must-revalidate
    - Vary: Authorization

- Prevents shared caching of authenticated responses for security/compliance

- BREAKING CHANGE: clients must update to use ?query= not ?q=