### PR TITLE
Enhance security and validation for template search functionality

### DIFF
--- a/backend/src/controllers/commandsController.js
+++ b/backend/src/controllers/commandsController.js
@@ -114,9 +114,14 @@ export class CommandController {
 
   search = async (req, res, next) => {
     try {
-      const { query: searchQuery, limit: resultLimit } = req.query;
+      const {
+        query: searchQuery,
+        q: legacySearchQuery,
+        limit: resultLimit,
+      } = req.query;
+      const resolvedSearchQuery = searchQuery ?? legacySearchQuery;
 
-      if (!searchQuery) {
+      if (!resolvedSearchQuery) {
         return next(
           new BadRequestError(
             "Query parameter 'query' is required and must be a non-empty string",
@@ -126,7 +131,7 @@ export class CommandController {
 
       const searchResults = await this.commandModel.searchTemplates({
         userId: req.user?.userId,
-        query: searchQuery,
+        query: resolvedSearchQuery,
         limit: resultLimit,
       });
 

--- a/backend/src/models/mongo/commandModel.js
+++ b/backend/src/models/mongo/commandModel.js
@@ -37,6 +37,9 @@ connect();
 const buildFilter = (base = {}, userId) =>
   userId !== undefined ? { ...base, userId } : base;
 
+const escapeRegex = (value = '') =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const MATCH_TYPES = {
   COMMAND_EXACT: 'command-exact',
   COMMAND_PREFIX: 'command-prefix',
@@ -149,8 +152,12 @@ export class CommandModel {
    * @param {string} params.query - Search query (keyword or /command)
    * @param {number} params.limit - Max results to return
    * @returns {Promise<Object>} Search results with templates array
+   * @throws {BadRequestError} If userId is not provided
    */
   searchTemplates = async ({ userId, query, limit }) => {
+    if (!userId) {
+      throw new BadRequestError('userId is required for searching templates');
+    }
     this.validateSearchQuery(query);
     const { trimmedQuery, queryLowercase, isCommandQuery } =
       this.normalizeSearchQuery(query);
@@ -176,9 +183,15 @@ export class CommandModel {
 
   /**
    * Validate search query meets minimum requirements
-   * @throws {BadRequestError} If query is empty or too long
+   * @throws {BadRequestError} If query is not a string, empty, or too long
    */
   validateSearchQuery = (query) => {
+    if (typeof query !== 'string') {
+      throw new BadRequestError(
+        "Query parameter 'query' must be a non-empty string",
+      );
+    }
+
     const trimmedQuery = query.trim();
 
     if (!trimmedQuery || trimmedQuery.length === 0) {
@@ -208,14 +221,24 @@ export class CommandModel {
 
   /**
    * Parse and validate search limit parameter
-   * @returns {number} Validated limit within allowed range
+   * @throws {BadRequestError} If limit is not a valid number
+   * @returns {number} Validated limit clamped to allowed range
    */
   parseSearchLimit = (limit) => {
+    if (limit === undefined || limit === null) {
+      return SEARCH_CONFIG.DEFAULT_LIMIT;
+    }
+
+    const parsed = Number(limit);
+
+    if (Number.isNaN(parsed)) {
+      throw new BadRequestError(
+        `Limit parameter must be a valid number between ${SEARCH_CONFIG.MIN_LIMIT} and ${SEARCH_CONFIG.MAX_LIMIT}`,
+      );
+    }
+
     return Math.min(
-      Math.max(
-        parseInt(limit) || SEARCH_CONFIG.DEFAULT_LIMIT,
-        SEARCH_CONFIG.MIN_LIMIT,
-      ),
+      Math.max(parsed, SEARCH_CONFIG.MIN_LIMIT),
       SEARCH_CONFIG.MAX_LIMIT,
     );
   };
@@ -288,10 +311,14 @@ export class CommandModel {
    * Find templates with exact command match
    */
   findExactCommandMatches = async (baseFilter, commandPrefix, limit) => {
+    const escapedOriginalQuery = escapeRegex(commandPrefix);
     return commandMongooseModel
       .find({
         ...baseFilter,
-        commandLower: commandPrefix,
+        $or: [
+          { commandLower: commandPrefix },
+          { command: { $regex: `^${escapedOriginalQuery}$` } },
+        ],
       })
       .select('_id name text command')
       .limit(limit);
@@ -307,10 +334,14 @@ export class CommandModel {
     limit,
   ) => {
     const excludedIds = excludedDocuments.map((doc) => doc._id);
+    const escapedQuery = escapeRegex(commandPrefix);
     return commandMongooseModel
       .find({
         ...baseFilter,
-        commandLower: { $regex: `^${commandPrefix}` },
+        $or: [
+          { commandLower: { $regex: `^${escapedQuery}` } },
+          { command: { $regex: `^${escapedQuery}` } },
+        ],
         _id: { $nin: excludedIds },
       })
       .select('_id name text command')
@@ -327,10 +358,14 @@ export class CommandModel {
     limit,
   ) => {
     const excludedIds = excludedDocuments.map((doc) => doc._id);
+    const escapedQuery = escapeRegex(commandPrefix);
     return commandMongooseModel
       .find({
         ...baseFilter,
-        commandLower: { $regex: commandPrefix },
+        $or: [
+          { commandLower: { $regex: escapedQuery } },
+          { command: { $regex: escapedQuery } },
+        ],
         _id: { $nin: excludedIds },
       })
       .select('_id name text command')
@@ -347,10 +382,16 @@ export class CommandModel {
     originalQuery,
     limit,
   ) => {
+    const escapedQuery = escapeRegex(queryLowercase);
+    const escapedOriginalQuery = escapeRegex(originalQuery);
     const contentMatches = await commandMongooseModel
       .find({
         ...baseFilter,
-        textLower: { $regex: queryLowercase, $options: 'i' },
+        $or: [
+          { textLower: { $regex: escapedQuery } },
+          { text: { $regex: escapedOriginalQuery } },
+          { name: { $regex: escapedOriginalQuery } },
+        ],
       })
       .select('_id name text command')
       .limit(limit)


### PR DESCRIPTION

- Controller: support legacy 'q' (in addition to 'query') as the search query param for backwards compatibility

- Model: add escapeRegex utility and use it on all user-provided query strings to prevent regex injection

- Always require userId in searchTemplates; throw BadRequestError if missing

- Validate query type: must be a non-empty string, else throw BadRequestError

- Robustify parseSearchLimit: handle undefined/null/non-numeric, clamp to min/max, throw on invalid

- $or matching for command/text/name fields (both lowercased/indexed and original versions) using escaped regex patterns for reliable, case-insensitive search

- Enhances security, results reliability, and input validation for command/template search