### PR TITLE
Enhance refresh token security with atomic consumption and revocation

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -148,8 +148,13 @@ export class AuthController {
         );
       }
 
-      // Rotate: consume old token, issue new token pair
-      await this.refreshTokenModel.consumeByHash(tokenHash);
+      // Atomically consume — guard against concurrent requests racing past the isConsumed check
+      const consumed = await this.refreshTokenModel.consumeByHash(tokenHash);
+      if (!consumed) {
+        await this.refreshTokenModel.revokeFamily(storedToken.familyId);
+        clearRefreshTokenCookie(res);
+        throw new UnauthorizedError('Token reuse detected. All sessions revoked.');
+      }
 
       const newRawRefreshToken = generateRefreshToken();
       const newTokenHash = hashToken(newRawRefreshToken);

--- a/backend/src/models/mongo/refreshTokenModel.js
+++ b/backend/src/models/mongo/refreshTokenModel.js
@@ -14,7 +14,7 @@ export class RefreshTokenModel {
 
   consumeByHash(tokenHash) {
     return RefreshToken.findOneAndUpdate(
-      { tokenHash, expiresAt: { $gt: new Date() } },
+      { tokenHash, isConsumed: false, expiresAt: { $gt: new Date() } },
       { isConsumed: true },
       { new: true },
     );

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -56,9 +56,11 @@ function createMockRefreshTokenModel() {
       return tokens.find((t) => t.tokenHash === tokenHash && t.expiresAt > new Date()) || null;
     }),
     consumeByHash: vi.fn(async (tokenHash) => {
-      const token = tokens.find((t) => t.tokenHash === tokenHash && t.expiresAt > new Date());
+      const token = tokens.find(
+        (t) => t.tokenHash === tokenHash && !t.isConsumed && t.expiresAt > new Date(),
+      );
       if (token) token.isConsumed = true;
-      return token;
+      return token || null;
     }),
     revokeFamily: vi.fn(async (familyId) => {
       const remaining = tokens.filter((t) => t.familyId !== familyId);
@@ -96,6 +98,12 @@ function parseCookies(res) {
   const cookieHeaders = res.headers['set-cookie'] || [];
   const cookies = {};
   for (const raw of cookieHeaders) {
+    if (
+      raw.includes('Max-Age=0') ||
+      raw.includes('Expires=Thu, 01 Jan 1970 00:00:00 GMT')
+    ) {
+      continue; // cookie being cleared — treat as absent
+    }
     const [nameVal] = raw.split(';');
     const [name, ...rest] = nameVal.split('=');
     cookies[name.trim()] = rest.join('=').trim();


### PR DESCRIPTION
- Model: consumeByHash now only matches tokens with isConsumed: false for atomic consumption, preventing race conditions during RT rotation
- Controller:
    - On token reuse (i.e., consumeByHash returns null), revoke all tokens in the token family (revokeFamily)
    - Clear the refresh-token (__rt) cookie
    - Return UnauthorizedError to indicate session compromise
- Tests:
    - Updated for new isConsumed predicate semantics
    - Adjusted cookie parser to ignore cleared/expired Set-Cookie headers
- Ensures correct, secure handling of refresh token theft/reuse with prompt session family invalidation