### PR TITLE
Enforce numeric ENV validation and add test suite setup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,22 @@
+# Server Configuration
+PORT=3000
+DATABASE_URL=mongodb://localhost:27017/commander
+
+# Auth Configuration (Required)
+AT_SECRET=your_at_secret_here
+CSRF_SECRET=your_csrf_secret_here
+JWT_SECRET=your_jwt_secret_here
+
+# Token Policies (Seconds/Milliseconds)
+AT_EXPIRY_SECONDS=900
+RT_EXPIRY_SECONDS=604800
+RT_BYTE_LENGTH=48
+RESET_PASSWORD_TOKEN_EXPIRY_MS=3600000
+
+# Email Configuration
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+EMAIL_FROM=
+FRONTEND_URL=http://localhost:3000

--- a/backend/src/config/constants.js
+++ b/backend/src/config/constants.js
@@ -1,14 +1,39 @@
 export const SALT_ROUNDS = 10;
 export const MIN_PASSWORD_LENGTH = 8;
-export const RESET_PASSWORD_TOKEN_EXPIRY_MS = 3600000;
+export const getResetPasswordTokenExpiryMs = () =>
+  getRequiredIntEnv('RESET_PASSWORD_TOKEN_EXPIRY_MS');
 
-// Token policy — values are runtime-configurable via environment variables
-export const getAtExpirySeconds = () =>
-  parseInt(process.env.AT_EXPIRY_SECONDS, 10);
-export const getRtExpirySeconds = () =>
-  parseInt(process.env.RT_EXPIRY_SECONDS, 10);
+// Helper to ensure numeric environment variables are present and valid
+/**
+ * Retrieves a required integer environment variable.
+ * Throws a startup error if the variable is missing or non-numeric.
+ *
+ * @param {string} key - The environment variable name.
+ * @returns {number} The parsed integer value.
+ * @throws {Error} If the environment variable is invalid or missing.
+ */
+function getRequiredIntEnv(key) {
+  const value = process.env[key];
+  const parsedValue = parseInt(value, 10);
+
+  if (isNaN(parsedValue)) {
+    throw new Error(
+      `Startup Error: Environment variable ${key} is required and must be a valid integer.`,
+    );
+  }
+
+  return parsedValue;
+}
+
+export const getAtExpirySeconds = () => getRequiredIntEnv('AT_EXPIRY_SECONDS');
+export const getRtExpirySeconds = () => getRequiredIntEnv('RT_EXPIRY_SECONDS');
 export const getRtExpiryMs = () => getRtExpirySeconds() * 1000;
-export const getRtByteLength = () => parseInt(process.env.RT_BYTE_LENGTH, 10);
+export const getRtByteLength = () => getRequiredIntEnv('RT_BYTE_LENGTH');
+
+getAtExpirySeconds();
+getRtExpirySeconds();
+getRtByteLength();
+getResetPasswordTokenExpiryMs();
 
 // Cookie names and paths
 export const RT_COOKIE_NAME = '__rt';

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -22,8 +22,8 @@ import {
 import { generateCsrfToken } from '../middleware/csrfMiddleware.js';
 import {
   SALT_ROUNDS,
-  RESET_PASSWORD_TOKEN_EXPIRY_MS,
   getRtExpirySeconds,
+  getResetPasswordTokenExpiryMs,
 } from '../config/constants.js';
 
 function formatAuthResponse(user, accessToken) {
@@ -220,7 +220,7 @@ export class AuthController {
       if (user) {
         const resetToken = generateRandomToken();
         const hashedToken = hashToken(resetToken);
-        const resetExpires = Date.now() + RESET_PASSWORD_TOKEN_EXPIRY_MS;
+        const resetExpires = Date.now() + getResetPasswordTokenExpiryMs();
 
         await this.userModel.updateResetFields(user._id, {
           resetToken: hashedToken,

--- a/backend/src/utils/passwordReset.js
+++ b/backend/src/utils/passwordReset.js
@@ -3,7 +3,7 @@ import { BadRequestError } from './errors.js';
 import { hashToken } from './auth.js';
 import {
   SALT_ROUNDS,
-  RESET_PASSWORD_TOKEN_EXPIRY_MS,
+  getResetPasswordTokenExpiryMs,
 } from '../config/constants.js';
 
 /**

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -5,15 +5,6 @@ import jwt from 'jsonwebtoken';
 import { createApp } from '../src/app.js';
 import { hashToken } from '../src/utils/auth.js';
 
-// --- Environment setup ---
-process.env.AT_SECRET = 'test-at-secret-64chars-long-enough-for-hmac-signing-xxxxxxxxxx';
-process.env.CSRF_SECRET = 'test-csrf-secret-64chars-long-enough-for-hmac-signing-xxxxxxxx';
-process.env.JWT_SECRET = 'test-jwt-secret';
-process.env.AT_EXPIRY_SECONDS = '2';
-process.env.RT_EXPIRY_SECONDS = '604800';
-process.env.RT_BYTE_LENGTH = '48';
-process.env.NODE_ENV = 'test';
-
 // --- In-memory mock factories ---
 
 function createMockUserModel() {
@@ -403,7 +394,6 @@ describe('Bifurcated Auth', () => {
 
     describe('Token expiration', () => {
       it('AT should expire after configured seconds', async () => {
-        // AT_EXPIRY_SECONDS=2 in test env
         const loginRes = await loginUser(app, {
           email: testUser.email,
           password: testUser.password,
@@ -412,7 +402,8 @@ describe('Bifurcated Auth', () => {
         const accessToken = loginRes.body.accessToken;
         const decoded = jwt.decode(accessToken);
 
-        const expectedExpiry = decoded.iat + 2;
+        const expirySeconds = parseInt(process.env.AT_EXPIRY_SECONDS, 10);
+        const expectedExpiry = decoded.iat + expirySeconds;
         expect(decoded.exp).toBe(expectedExpiry);
       });
 

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -1,0 +1,17 @@
+import 'dotenv/config';
+
+/**
+ * Global test setup.
+ * Environment variables are loaded from .env (which is git-ignored).
+ * If required variables are missing, the application will throw a 
+ * Startup Error during module import (see src/config/constants.js).
+ */
+
+process.env.NODE_ENV = 'test';
+
+// Only set secrets if they are absolutely required for the test environment 
+// to initialize and are not sensitive/production values.
+// Otherwise, they should be in .env.
+if (!process.env.AT_SECRET) process.env.AT_SECRET = 'test-at-secret-64chars-long-enough-for-hmac-signing-xxxxxxxxxx';
+if (!process.env.CSRF_SECRET) process.env.CSRF_SECRET = 'test-csrf-secret-64chars-long-enough-for-hmac-signing-xxxxxxxx';
+if (!process.env.JWT_SECRET) process.env.JWT_SECRET = 'test-jwt-secret';

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -5,5 +5,6 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     testTimeout: 15000,
+    setupFiles: ['./tests/setup.js'],
   },
 });


### PR DESCRIPTION
- Add .env.example with documented keys for local/dev onboarding
- Implement getRequiredIntEnv helper for robust required numeric ENV validation (fail-fast on misconfig)
- Replace direct parseInt uses with getRequiredIntEnv (AT/RT expiry, RT byte length, reset token expiry)
- Move all numeric config parsing to import-time with clear error throwing
- Update password-reset utils and auth controller to use new config getters
- Add tests/setup.js for global test suite initialization
    - Move environment setup/teardown logic out of auth.test.js to setup.js
    - Compute AT expiry dynamically in auth test from environment rather than hardcode
- Register tests/setup.js as Vitest globalSetup in vitest.config.js