### PR TITLE
Refactor secret loading and validation in config module

### DIFF
--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -54,3 +54,12 @@ export const validateSmtpConfig = () => {
 
 export const EMAIL_FROM = process.env.EMAIL_FROM;
 export const FRONTEND_URL = process.env.FRONTEND_URL;
+
+export const JWT_SECRET = process.env.JWT_SECRET;
+export const AT_SECRET = process.env.AT_SECRET || process.env.JWT_SECRET;
+
+if (!AT_SECRET) {
+  throw new Error(
+    'Startup Error: AT_SECRET or JWT_SECRET must be set in environment variables.',
+  );
+}

--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken';
 import { UnauthorizedError } from '../utils/errors.js';
+import { AT_SECRET } from '../config/config.js';
 
 export const authMiddleware = (req, res, next) => {
   const authHeader = req.headers['authorization'];
@@ -15,8 +16,7 @@ export const authMiddleware = (req, res, next) => {
   }
 
   try {
-    const secret = process.env.AT_SECRET || process.env.JWT_SECRET;
-    const decoded = jwt.verify(token, secret);
+    const decoded = jwt.verify(token, AT_SECRET);
     req.user = {
       userId: decoded.userId,
       username: decoded.username,

--- a/backend/src/utils/auth.js
+++ b/backend/src/utils/auth.js
@@ -1,11 +1,12 @@
 import jwt from 'jsonwebtoken';
 import crypto from 'node:crypto';
 import { getAtExpirySeconds, getRtByteLength } from '../config/constants.js';
+import { JWT_SECRET, AT_SECRET } from '../config/config.js';
 
 // --- Legacy v1 token (preserved for backward compatibility) ---
 
 export const createToken = (userId, username) => {
-  return jwt.sign({ userId, username }, process.env.JWT_SECRET, {
+  return jwt.sign({ userId, username }, JWT_SECRET, {
     expiresIn: process.env.JWT_EXPIRY || '1d',
   });
 };
@@ -21,13 +22,13 @@ export const generateRandomToken = () => {
 // --- Access Token (v2 bifurcated auth) ---
 
 export const createAccessToken = (userId, username) => {
-  return jwt.sign({ userId, username }, process.env.AT_SECRET, {
+  return jwt.sign({ userId, username }, AT_SECRET, {
     expiresIn: getAtExpirySeconds(),
   });
 };
 
 export const verifyAccessToken = (token) => {
-  return jwt.verify(token, process.env.AT_SECRET);
+  return jwt.verify(token, AT_SECRET);
 };
 
 // --- Refresh Token (v2 bifurcated auth) ---


### PR DESCRIPTION
- Move JWT_SECRET and AT_SECRET loading to config module
    - AT_SECRET defaults to JWT_SECRET for backward compatibility
    - Validate at least one secret is set at startup (fail-fast if missing)
- Update authMiddleware and auth utilities to import secrets from config, not process.env
- Ensures consistent and early-secured handling of all JWT secret usage
- Legacy JWT uses JWT_SECRET, v2 access tokens use AT_SECRET per bifurcated-auth spec