### PR TITLE
Enable CORS with explicit origin and update SameSite cookie policy

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -7,11 +7,17 @@ import { requestLogger } from './middleware/loggerMiddleware.js';
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './config/swagger.js';
+import { FRONTEND_URL } from './config/config.js';
 
 export const createApp = ({ commandModel, userModel, refreshTokenModel }) => {
   const app = express();
 
-  app.use(cors());
+  app.use(
+    cors({
+      origin: FRONTEND_URL,
+      credentials: true,
+    }),
+  );
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   app.use(cookieParser());

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -16,6 +16,7 @@ export const createApp = ({ commandModel, userModel, refreshTokenModel }) => {
     cors({
       origin: FRONTEND_URL,
       credentials: true,
+      allowedHeaders: ['Content-Type', 'Authorization', 'x-csrf-token'],
     }),
   );
   app.use(express.json());

--- a/backend/src/config/config.js
+++ b/backend/src/config/config.js
@@ -57,9 +57,22 @@ export const FRONTEND_URL = process.env.FRONTEND_URL;
 
 export const JWT_SECRET = process.env.JWT_SECRET;
 export const AT_SECRET = process.env.AT_SECRET || process.env.JWT_SECRET;
+export const CSRF_SECRET = process.env.CSRF_SECRET;
 
-if (!AT_SECRET) {
+const requiredEnvVars = [
+  { value: AT_SECRET, name: 'AT_SECRET (or JWT_SECRET)' },
+  { value: CSRF_SECRET, name: 'CSRF_SECRET' },
+  { value: FRONTEND_URL, name: 'FRONTEND_URL' },
+];
+
+for (const { value, name } of requiredEnvVars) {
+  if (!value) {
+    throw new Error(`Startup Error: ${name} must be set in environment variables.`);
+  }
+}
+
+if (FRONTEND_URL === '*') {
   throw new Error(
-    'Startup Error: AT_SECRET or JWT_SECRET must be set in environment variables.',
+    'Startup Error: FRONTEND_URL cannot be "*" when credentials are enabled. Provide an explicit origin.',
   );
 }

--- a/backend/src/middleware/csrfMiddleware.js
+++ b/backend/src/middleware/csrfMiddleware.js
@@ -10,7 +10,7 @@ export const { doubleCsrfProtection, generateCsrfToken } = doubleCsrf({
   cookieOptions: {
     httpOnly: false, // frontend must read this cookie to send in x-csrf-token header
     secure: isProduction(),
-    sameSite: 'strict',
+    sameSite: isProduction() ? 'none' : 'lax',
     path: '/',
   },
   getCsrfTokenFromRequest: (req) => req.headers['x-csrf-token'],

--- a/backend/src/utils/cookies.js
+++ b/backend/src/utils/cookies.js
@@ -6,7 +6,7 @@ export const setRefreshTokenCookie = (res, token) => {
   res.cookie(RT_COOKIE_NAME, token, {
     httpOnly: true,
     secure: isProduction(),
-    sameSite: 'strict',
+    sameSite: isProduction() ? 'none' : 'lax',
     path: RT_COOKIE_PATH,
     maxAge: getRtExpiryMs(),
   });
@@ -16,7 +16,7 @@ export const clearRefreshTokenCookie = (res) => {
   res.clearCookie(RT_COOKIE_NAME, {
     httpOnly: true,
     secure: isProduction(),
-    sameSite: 'strict',
+    sameSite: isProduction() ? 'none' : 'lax',
     path: RT_COOKIE_PATH,
   });
 };

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -151,7 +151,7 @@ describe('Bifurcated Auth', () => {
       expect(cookies).toHaveProperty('__csrf');
     });
 
-    it('should set __rt cookie with httpOnly and sameSite=Strict', async () => {
+    it('should set __rt cookie with httpOnly and sameSite=Lax (in development)', async () => {
       const { app } = buildApp();
 
       const res = await registerUser(app, testUser);
@@ -161,7 +161,7 @@ describe('Bifurcated Auth', () => {
 
       expect(rtCookie).toBeDefined();
       expect(rtCookie).toContain('HttpOnly');
-      expect(rtCookie).toContain('SameSite=Strict');
+      expect(rtCookie).toContain('SameSite=Lax');
       expect(rtCookie).toContain('Path=/api/v2/auth');
     });
 


### PR DESCRIPTION
This pull request improves the backend's security and cross-origin compatibility by tightening CORS configuration, enforcing required environment variables, and updating cookie policies for better integration with frontend applications. The changes ensure that only explicitly allowed origins can access backend resources with credentials, and that cookie handling is compatible with cross-site requests, especially in production.

**CORS and Environment Configuration:**

* The `cors` middleware in `app.js` is now configured to accept requests only from the `FRONTEND_URL` environment variable, with credentials enabled and a restricted set of allowed headers. This prevents unauthorized origins from accessing the backend when credentials are involved.
* The backend now checks at startup that `AT_SECRET`, `CSRF_SECRET`, and `FRONTEND_URL` environment variables are set, throwing clear errors if any are missing. Additionally, it prevents the use of a wildcard (`*`) for `FRONTEND_URL` when credentials are enabled, enforcing explicit origin specification for security.

**Cookie and CSRF Policy Adjustments:**

* The `sameSite` attribute for both refresh token and CSRF cookies is now set to `'none'` in production and `'lax'` in development, instead of always `'strict'`. This change allows cookies to be sent with cross-site requests in production, which is necessary for frontend-backend integration when they are on different domains. [[1]](diffhunk://#diff-3dc5fe27fdbfeec091ff98dbb27b9e24e4074c7f471ba617b9e4cc182fe6ccdfL9-R9) [[2]](diffhunk://#diff-3dc5fe27fdbfeec091ff98dbb27b9e24e4074c7f471ba617b9e4cc182fe6ccdfL19-R19) [[3]](diffhunk://#diff-f2f2a794b03397a6d7263c6ec6e279d332aa84962c30fc5b1b14bcb142e1ee5cL13-R13)

**Testing Updates:**

* The authentication tests have been updated to expect `SameSite=Lax` for the refresh token cookie in development, reflecting the new default behavior. [[1]](diffhunk://#diff-ddf86dcac3bef9cd455b4758063f4a905de849088473720d36e5bfca652c7385L154-R154) [[2]](diffhunk://#diff-ddf86dcac3bef9cd455b4758063f4a905de849088473720d36e5bfca652c7385L164-R164)