### PR TITLE
Include tokens and user info in frontend redirect after Google OAuth

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -345,9 +345,16 @@ export class AuthController {
         }
       }
 
-      await issueTokenPair(req, res, this.refreshTokenModel, user);
+      const { accessToken, csrfToken } = await issueTokenPair(req, res, this.refreshTokenModel, user);
 
-      res.redirect(FRONTEND_URL);
+      const params = new URLSearchParams({
+        accessToken,
+        csrfToken,
+        userId: String(user._id),
+        username: user.username,
+        email: user.email,
+      });
+      res.redirect(`${FRONTEND_URL}?${params}`);
     } catch (error) {
       res.redirect(`${FRONTEND_URL}/login?error=oauth_failed`);
     }


### PR DESCRIPTION
This pull request updates the OAuth login flow in the `AuthController` to improve how authentication data is passed to the frontend. Instead of just redirecting to the frontend after login, the backend now includes important authentication tokens and user information as URL parameters in the redirect.

**OAuth redirect improvements:**

* The `AuthController` now redirects to the frontend with `accessToken`, `csrfToken`, `userId`, `username`, and `email` included as URL query parameters after successful OAuth login. This allows the frontend to immediately access authentication and user data upon redirect.